### PR TITLE
Added an option to filter which request to log based on the sending tool (Proxy, Repeater, Intruder, Extender...)

### DIFF
--- a/src/main/java/burp/ActivityHttpListener.java
+++ b/src/main/java/burp/ActivityHttpListener.java
@@ -84,7 +84,7 @@ class ActivityHttpListener implements HttpHandler {
             mustLogRequest = false;
         } else {
             //First: We check if we must apply restriction about tool source
-            if (ConfigMenu.FILTER_BY_TOOL_SOURCE && ConfigMenu.EXCLUDED_TOOL_SOURCES.contains(toolName)) {
+            if (ConfigMenu.FILTER_BY_TOOL_SOURCE && !ConfigMenu.INCLUDED_TOOL_SOURCES.contains(toolName)) {
                 mustLogRequest = false;
             }
             //Second: We check if we must apply restriction about image resource


### PR DESCRIPTION
Hi there :)

First, thanks for taking the time to maintain this extension and for the rewrite under the montoya API :)

In the past, when using the extension on large bug bounty targets and extensive sessions, I had some performance issues, notably with scans or when browsing in parallel with different browsers / sessions.

I would like to implement a couple of new features in this extension amongst which :

1/Async writes to the DB
2/The ability to batch push requests to a postgreSQL database.
3/Some additional configuration options on the type of traffic to be logged (ex: being able to exclude intruder traffic temporarly)
This pull request implements 3/Some additional configuration options on the type of traffic to be logged (ex: being able to exclude intruder traffic temporarly)

Disclosure: I (really) suck at Java, so this code was generated through the help of Claude 4. I then proceeded to : 
- test the code through building it and stress-testing the extension (multiple browsers, directory brute-force through intruder...)
- enable/disable/re-enable the intruder and repeater logging and ensure the logging actions were updated accordingly in the database 