### PR TITLE
Added a postgresql connector + async writes / batching by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+mise.toml

--- a/README.md
+++ b/README.md
@@ -183,3 +183,99 @@ Procedure kindly provided by the PortSwigger support:
 # SQLite client
 
 Cross-platform: https://github.com/sqlitebrowser/sqlitebrowser
+
+# Burp Suite Activity Logger - PostgreSQL Database Setup
+
+This Docker Compose configuration sets up a PostgreSQL database for the Burp Suite Activity Logger extension.
+
+## Quick Start
+
+1. **Start the database:**
+   ```bash
+   docker-compose up -d
+   ```
+
+2. **Configure your Burp Suite extension with these connection parameters:**
+   - **Host:** `localhost`
+   - **Port:** `5432`
+   - **Database:** `burp_activity`
+   - **Username:** `burp_user`
+   - **Password:** `burp_password`
+
+3. **Stop the database:**
+   ```bash
+   docker-compose down
+   ```
+
+## Services Included
+
+### PostgreSQL Database
+- **Container:** `burp-activity-db`
+- **Port:** 5432 (exposed to host)
+- **Database:** `burp_activity`
+- **User:** `burp_user`
+- **Password:** `burp_password`
+
+### pgAdmin (Optional)
+- **Container:** `burp-pgadmin`
+- **Port:** 8080 (web interface)
+- **Email:** `admin@example.com`
+- **Password:** `admin`
+
+To start with pgAdmin included:
+```bash
+docker-compose --profile admin up -d
+```
+
+## Data Persistence
+
+Database data is stored in a Docker volume named `postgres_data`, so your data will persist between container restarts.
+
+## Database Schema
+
+The database automatically creates an `ACTIVITY` table with the following structure:
+- `id` - Primary key (auto-increment)
+- `local_source_ip` - Source IP address
+- `target_url` - Target URL of the request
+- `http_method` - HTTP method (GET, POST, etc.)
+- `burp_tool` - Burp Suite tool that generated the request
+- `request_raw` - Raw HTTP request
+- `send_datetime` - When the request was sent
+- `http_status_code` - HTTP response status code
+- `response_raw` - Raw HTTP response
+- `created_at` - When the record was created
+
+## Performance Optimizations
+
+The setup includes several performance optimizations:
+- Indexes on commonly queried columns
+- Proper user permissions
+- Health checks for container monitoring
+
+## Customization
+
+You can modify the following in `docker-compose.yml`:
+- Database name, username, and password in the `environment` section
+- Port mappings if you need different ports
+- Volume configurations for data storage
+
+## Troubleshooting
+
+1. **Connection refused errors:**
+   - Ensure the container is running: `docker-compose ps`
+   - Check container logs: `docker-compose logs postgres`
+
+2. **Permission errors:**
+   - The init script sets up proper permissions automatically
+   - If issues persist, check the logs: `docker-compose logs postgres`
+
+3. **Data not persisting:**
+   - Ensure the volume is properly created: `docker volume ls`
+   - Check that the container has write permissions
+
+## Security Notes
+
+- The default credentials are for development only
+- For production use, change the default passwords
+- Consider using Docker secrets for sensitive information
+- Restrict network access as needed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    container_name: burp-activity-db
+    environment:
+      POSTGRES_DB: burp_activity
+      POSTGRES_USER: burp_user
+      POSTGRES_PASSWORD: burp_password
+      POSTGRES_INITDB_ARGS: "--encoding=UTF8"
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U burp_user -d burp_activity"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Optional: pgAdmin for database management
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: burp-pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_CONFIG_SERVER_MODE: 'False'
+    ports:
+      - "8080:80"
+    depends_on:
+      - postgres
+    restart: unless-stopped
+    profiles:
+      - admin
+
+volumes:
+  postgres_data:
+    driver: local 

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,35 @@
+-- Initialize the database for Burp Suite Activity Logger
+-- This script runs automatically when the container starts for the first time
+
+-- Grant necessary permissions to the burp_user
+GRANT ALL PRIVILEGES ON DATABASE burp_activity TO burp_user;
+
+-- Create the activity table (this will also be created by the Java extension, but having it here ensures it exists)
+CREATE TABLE IF NOT EXISTS ACTIVITY (
+    id SERIAL PRIMARY KEY,
+    local_source_ip TEXT,
+    target_url TEXT,
+    http_method TEXT,
+    burp_tool TEXT,
+    request_raw TEXT,
+    send_datetime TIMESTAMP,
+    http_status_code TEXT,
+    response_raw TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Grant permissions on the table
+GRANT ALL PRIVILEGES ON TABLE ACTIVITY TO burp_user;
+GRANT USAGE, SELECT ON SEQUENCE activity_id_seq TO burp_user;
+
+-- Create indexes for better performance on common queries
+CREATE INDEX IF NOT EXISTS idx_activity_send_datetime ON ACTIVITY(send_datetime);
+CREATE INDEX IF NOT EXISTS idx_activity_http_method ON ACTIVITY(http_method);
+CREATE INDEX IF NOT EXISTS idx_activity_burp_tool ON ACTIVITY(burp_tool);
+CREATE INDEX IF NOT EXISTS idx_activity_target_url ON ACTIVITY(target_url);
+
+-- Log initialization completion
+DO $$
+BEGIN
+    RAISE NOTICE 'Burp Activity Logger database initialized successfully';
+END $$; 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.49.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/burp/ActivityHttpListener.java
+++ b/src/main/java/burp/ActivityHttpListener.java
@@ -13,7 +13,7 @@ class ActivityHttpListener implements HttpHandler {
     /**
      * Ref on handler that will store the activity information into the activity log storage.
      */
-    private ActivityLogger activityLogger;
+    private ActivityStorage activityStorage;
 
     /**
      * Ref on project logger.
@@ -23,11 +23,11 @@ class ActivityHttpListener implements HttpHandler {
     /**
      * Constructor.
      *
-     * @param activityLogger    Ref on handler that will store the activity information into the activity log storage.
+     * @param activityStorage   Ref on handler that will store the activity information into the activity log storage.
      * @param trace             Ref on project logger.
      */
-    ActivityHttpListener(ActivityLogger activityLogger, Trace trace) {
-        this.activityLogger = activityLogger;
+    ActivityHttpListener(ActivityStorage activityStorage, Trace trace) {
+        this.activityStorage = activityStorage;
         this.trace = trace;
     }
 
@@ -38,7 +38,7 @@ class ActivityHttpListener implements HttpHandler {
         if (!ConfigMenu.INCLUDE_HTTP_RESPONSE_CONTENT) {
             try {
                 if (this.mustLogRequest(requestToBeSent)) {
-                    this.activityLogger.logEvent(requestToBeSent, null, requestToBeSent.toolSource().toolType().toolName());
+                    this.activityStorage.logEvent(requestToBeSent, null, requestToBeSent.toolSource().toolType().toolName());
                 }
             } catch (Exception e) {
                 this.trace.writeLog("Cannot save request: " + e.getMessage());
@@ -57,7 +57,7 @@ class ActivityHttpListener implements HttpHandler {
             try {
                 //Save the information of the current request if the message is an HTTP response and according to the restriction options
                 if (this.mustLogRequest(responseReceived.initiatingRequest())) {
-                    this.activityLogger.logEvent(responseReceived.initiatingRequest(), responseReceived, responseReceived.toolSource().toolType().toolName());
+                    this.activityStorage.logEvent(responseReceived.initiatingRequest(), responseReceived, responseReceived.toolSource().toolType().toolName());
                 }
             } catch (Exception e) {
                 this.trace.writeLog("Cannot save response: " + e.getMessage());

--- a/src/main/java/burp/ActivityHttpListener.java
+++ b/src/main/java/burp/ActivityHttpListener.java
@@ -31,6 +31,17 @@ class ActivityHttpListener implements HttpHandler {
         this.trace = trace;
     }
 
+    /**
+     * Replace the current activity storage with a new one.
+     * This allows switching between storage backends without restarting Burp Suite.
+     *
+     * @param newStorage The new storage instance to use
+     */
+    void replaceStorage(ActivityStorage newStorage) {
+        this.activityStorage = newStorage;
+        this.trace.writeLog("HTTP listener activity storage replaced.");
+    }
+
     @Override
     public RequestToBeSentAction handleHttpRequestToBeSent(HttpRequestToBeSent requestToBeSent)
     {

--- a/src/main/java/burp/ActivityStorage.java
+++ b/src/main/java/burp/ActivityStorage.java
@@ -1,0 +1,33 @@
+package burp;
+
+import burp.api.montoya.http.message.requests.HttpRequest;
+import burp.api.montoya.http.message.responses.HttpResponse;
+import burp.api.montoya.extension.ExtensionUnloadingHandler;
+
+/**
+ * Interface for activity storage implementations.
+ * This allows for different storage backends (SQLite, PostgreSQL, etc.)
+ * while maintaining a consistent API.
+ */
+interface ActivityStorage extends ExtensionUnloadingHandler {
+
+    /**
+     * Save an activity event into the storage.
+     *
+     * @param request       HttpRequest object containing all information about the request
+     *                      which was either sent or will be sent out soon.
+     * @param response      HttpResponse object containing all information about the response.
+     *                      Is null when only the request is stored.
+     * @param tool          The name of the tool which was used to issue the request.
+     * @throws Exception    If event cannot be saved.
+     */
+    void logEvent(HttpRequest request, HttpResponse response, String tool) throws Exception;
+
+    /**
+     * Extract and compute statistics about the storage.
+     *
+     * @return A VO object containing the statistics.
+     * @throws Exception If computation meets an error.
+     */
+    DBStats getEventsStats() throws Exception;
+} 

--- a/src/main/java/burp/ActivityStorageFactory.java
+++ b/src/main/java/burp/ActivityStorageFactory.java
@@ -1,0 +1,137 @@
+package burp;
+
+import burp.api.montoya.MontoyaApi;
+import burp.api.montoya.persistence.Preferences;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.JTextField;
+import javax.swing.JPasswordField;
+import javax.swing.JPanel;
+import javax.swing.JLabel;
+import java.awt.GridLayout;
+
+/**
+ * Factory class to create the appropriate activity storage instance based on configuration.
+ */
+class ActivityStorageFactory {
+
+    /**
+     * Create an activity storage instance based on configuration preferences.
+     *
+     * @param preferences   Preferences for configuration
+     * @param storeName     SQLite database file path (used if SQLite is selected)
+     * @param api           MontoyaApi instance
+     * @param trace         Trace logger
+     * @return              ActivityStorage instance
+     * @throws Exception    If storage creation fails
+     */
+    static ActivityStorage createStorage(Preferences preferences, String storeName, MontoyaApi api, Trace trace) throws Exception {
+        boolean usePostgreSQL = Boolean.TRUE.equals(preferences.getBoolean(ConfigMenu.USE_POSTGRESQL_CFG_KEY));
+        
+        if (usePostgreSQL) {
+            return createPostgreSQLStorage(preferences, api, trace);
+        } else {
+            return createSQLiteStorage(storeName, api, trace);
+        }
+    }
+
+    /**
+     * Create SQLite storage instance.
+     */
+    private static ActivityStorage createSQLiteStorage(String storeName, MontoyaApi api, Trace trace) throws Exception {
+        return new ActivityLogger(storeName, api, trace);
+    }
+
+    /**
+     * Create PostgreSQL storage instance.
+     */
+    private static ActivityStorage createPostgreSQLStorage(Preferences preferences, MontoyaApi api, Trace trace) throws Exception {
+        String host = preferences.getString(ConfigMenu.POSTGRESQL_HOST_CFG_KEY);
+        String portStr = preferences.getString(ConfigMenu.POSTGRESQL_PORT_CFG_KEY);
+        String database = preferences.getString(ConfigMenu.POSTGRESQL_DATABASE_CFG_KEY);
+        String username = preferences.getString(ConfigMenu.POSTGRESQL_USERNAME_CFG_KEY);
+        String password = preferences.getString(ConfigMenu.POSTGRESQL_PASSWORD_CFG_KEY);
+
+        // Set defaults if not configured
+        if (host == null || host.trim().isEmpty()) {
+            host = "localhost";
+        }
+        
+        int port = 5432; // Default PostgreSQL port
+        if (portStr != null && !portStr.trim().isEmpty()) {
+            try {
+                port = Integer.parseInt(portStr.trim());
+            } catch (NumberFormatException e) {
+                trace.writeLog("Invalid PostgreSQL port, using default 5432");
+            }
+        }
+        
+        if (database == null || database.trim().isEmpty()) {
+            database = "burp_requests";
+        }
+        
+        if (username == null || username.trim().isEmpty()) {
+            username = "postgres";
+        }
+        
+        if (password == null) {
+            password = "";
+        }
+
+        return new PostgreSQLActivityLogger(host, port, database, username, password, api, trace);
+    }
+
+    /**
+     * Show PostgreSQL connection configuration dialog.
+     *
+     * @param preferences   Preferences to save configuration
+     * @param parentFrame   Parent frame for dialog
+     * @return              true if user confirmed, false if cancelled
+     */
+    static boolean showPostgreSQLConfigDialog(Preferences preferences, JFrame parentFrame) {
+        JPanel panel = new JPanel(new GridLayout(5, 2, 5, 5));
+        
+        String currentHost = preferences.getString(ConfigMenu.POSTGRESQL_HOST_CFG_KEY);
+        String currentPort = preferences.getString(ConfigMenu.POSTGRESQL_PORT_CFG_KEY);
+        String currentDatabase = preferences.getString(ConfigMenu.POSTGRESQL_DATABASE_CFG_KEY);
+        String currentUsername = preferences.getString(ConfigMenu.POSTGRESQL_USERNAME_CFG_KEY);
+        String currentPassword = preferences.getString(ConfigMenu.POSTGRESQL_PASSWORD_CFG_KEY);
+
+        JTextField hostField = new JTextField(currentHost != null ? currentHost : "localhost");
+        JTextField portField = new JTextField(currentPort != null ? currentPort : "5432");
+        JTextField databaseField = new JTextField(currentDatabase != null ? currentDatabase : "burp_requests");
+        JTextField usernameField = new JTextField(currentUsername != null ? currentUsername : "postgres");
+        JPasswordField passwordField = new JPasswordField(currentPassword != null ? currentPassword : "");
+
+        panel.add(new JLabel("Host:"));
+        panel.add(hostField);
+        panel.add(new JLabel("Port:"));
+        panel.add(portField);
+        panel.add(new JLabel("Database:"));
+        panel.add(databaseField);
+        panel.add(new JLabel("Username:"));
+        panel.add(usernameField);
+        panel.add(new JLabel("Password:"));
+        panel.add(passwordField);
+
+        int result = JOptionPane.showConfirmDialog(
+            parentFrame,
+            panel,
+            "PostgreSQL Connection Configuration",
+            JOptionPane.OK_CANCEL_OPTION,
+            JOptionPane.PLAIN_MESSAGE
+        );
+
+        if (result == JOptionPane.OK_OPTION) {
+            // Save configuration
+            preferences.setString(ConfigMenu.POSTGRESQL_HOST_CFG_KEY, hostField.getText().trim());
+            preferences.setString(ConfigMenu.POSTGRESQL_PORT_CFG_KEY, portField.getText().trim());
+            preferences.setString(ConfigMenu.POSTGRESQL_DATABASE_CFG_KEY, databaseField.getText().trim());
+            preferences.setString(ConfigMenu.POSTGRESQL_USERNAME_CFG_KEY, usernameField.getText().trim());
+            preferences.setString(ConfigMenu.POSTGRESQL_PASSWORD_CFG_KEY, new String(passwordField.getPassword()));
+            return true;
+        }
+
+        return false;
+    }
+} 

--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -148,7 +148,7 @@ public class BurpExtender implements BurpExtension {
             ActivityStorage activityStorage = ActivityStorageFactory.createStorage(preferences, customStoreFileName, this.api, trace);
             ActivityHttpListener activityHttpListener = new ActivityHttpListener(activityStorage, trace);
             //Setup the configuration menu
-            configMenu = new ConfigMenu(this.api, trace, activityStorage);
+            configMenu = new ConfigMenu(this.api, trace, activityStorage, activityHttpListener);
             SwingUtilities.invokeLater(configMenu);
             //Register all listeners
             this.api.http().registerHttpHandler(activityHttpListener);

--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -45,47 +45,114 @@ public class BurpExtender implements BurpExtension {
                 customStoreFileName = defaultStoreFileName;
             }
             Boolean isLoggingPaused = Boolean.TRUE.equals(preferences.getBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY));
+            Boolean usePostgreSQL = Boolean.TRUE.equals(preferences.getBoolean(ConfigMenu.USE_POSTGRESQL_CFG_KEY));
+            
             if (!isLoggingPaused) {
-                Object[] options = {"Keep the DB file", "Change the DB file", "Pause the logging"};
-                String msg = "Continue to log events into the following database file?\n\r" + customStoreFileName;
+                String msg;
+                Object[] options;
+                
+                if (usePostgreSQL) {
+                    // Check if PostgreSQL is configured
+                    String pgHost = preferences.getString(ConfigMenu.POSTGRESQL_HOST_CFG_KEY);
+                    String pgDb = preferences.getString(ConfigMenu.POSTGRESQL_DATABASE_CFG_KEY);
+                    if (pgHost == null || pgHost.trim().isEmpty() || pgDb == null || pgDb.trim().isEmpty()) {
+                        // PostgreSQL not configured, ask user to configure
+                        msg = "PostgreSQL storage is enabled but not configured. Would you like to configure it now?";
+                        options = new Object[]{"Configure PostgreSQL", "Use SQLite instead", "Pause the logging"};
+                    } else {
+                        msg = "Continue to log events into PostgreSQL database?\n\rHost: " + pgHost + "\n\rDatabase: " + pgDb;
+                        options = new Object[]{"Continue", "Reconfigure PostgreSQL", "Pause the logging"};
+                    }
+                } else {
+                    msg = "Continue to log events into the following SQLite database file?\n\r" + customStoreFileName;
+                    options = new Object[]{"Keep the DB file", "Change the DB file", "Pause the logging"};
+                }
                 //Mapping of the buttons with the dialog: options[0] => YES / options[1] => NO / options[2] => CANCEL
                 int loggingQuestionReply = JOptionPane.showOptionDialog(burpFrame, msg, extensionName, JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE, null, options, null);
-                //Case for YES is already handled, use the stored file
-                if (loggingQuestionReply == JOptionPane.YES_OPTION) {
-                    preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.FALSE);
-                    this.api.logging().logToOutput("Logging is enabled.");
-                }
-                //Case for the NO => Change DB file
-                if (loggingQuestionReply == JOptionPane.NO_OPTION) {
-                    JFileChooser customStoreFileNameFileChooser = Utilities.createDBFileChooser();
-                    int dbFileSelectionReply = customStoreFileNameFileChooser.showDialog(burpFrame, "Use");
-                    if (dbFileSelectionReply == JFileChooser.APPROVE_OPTION) {
-                        customStoreFileName = customStoreFileNameFileChooser.getSelectedFile().getAbsolutePath().replaceAll("\\\\", "/");
-                    } else {
-                        JOptionPane.showMessageDialog(burpFrame, "The following database file will continue to be used:\n\r" + customStoreFileName, extensionName, JOptionPane.INFORMATION_MESSAGE);
+                
+                if (usePostgreSQL) {
+                    //Case for YES (Continue/Configure PostgreSQL)
+                    if (loggingQuestionReply == JOptionPane.YES_OPTION) {
+                        String pgHost = preferences.getString(ConfigMenu.POSTGRESQL_HOST_CFG_KEY);
+                        String pgDb = preferences.getString(ConfigMenu.POSTGRESQL_DATABASE_CFG_KEY);
+                        if (pgHost == null || pgHost.trim().isEmpty() || pgDb == null || pgDb.trim().isEmpty()) {
+                            // Configure PostgreSQL
+                            if (ActivityStorageFactory.showPostgreSQLConfigDialog(preferences, burpFrame)) {
+                                preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.FALSE);
+                                this.api.logging().logToOutput("PostgreSQL storage configured and logging is enabled.");
+                            } else {
+                                preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.TRUE);
+                                this.api.logging().logToOutput("PostgreSQL configuration cancelled. Logging is paused.");
+                            }
+                        } else {
+                            preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.FALSE);
+                            this.api.logging().logToOutput("PostgreSQL logging is enabled.");
+                        }
                     }
-                    preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.FALSE);
-                    this.api.logging().logToOutput("Logging is enabled.");
-                }
-                //Case for the CANCEL => Pause the logging
-                if (loggingQuestionReply == JOptionPane.CANCEL_OPTION) {
-                    preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.TRUE);
-                    this.api.logging().logToOutput("Logging is paused.");
+                    //Case for NO (Use SQLite instead/Reconfigure PostgreSQL)
+                    if (loggingQuestionReply == JOptionPane.NO_OPTION) {
+                        String pgHost = preferences.getString(ConfigMenu.POSTGRESQL_HOST_CFG_KEY);
+                        String pgDb = preferences.getString(ConfigMenu.POSTGRESQL_DATABASE_CFG_KEY);
+                        if (pgHost == null || pgHost.trim().isEmpty() || pgDb == null || pgDb.trim().isEmpty()) {
+                            // Use SQLite instead
+                            preferences.setBoolean(ConfigMenu.USE_POSTGRESQL_CFG_KEY, Boolean.FALSE);
+                            preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.FALSE);
+                            this.api.logging().logToOutput("Switched to SQLite storage and logging is enabled.");
+                        } else {
+                            // Reconfigure PostgreSQL
+                            if (ActivityStorageFactory.showPostgreSQLConfigDialog(preferences, burpFrame)) {
+                                preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.FALSE);
+                                this.api.logging().logToOutput("PostgreSQL storage reconfigured and logging is enabled.");
+                            } else {
+                                preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.FALSE);
+                                this.api.logging().logToOutput("PostgreSQL configuration unchanged. Logging is enabled.");
+                            }
+                        }
+                    }
+                    //Case for CANCEL => Pause the logging
+                    if (loggingQuestionReply == JOptionPane.CANCEL_OPTION) {
+                        preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.TRUE);
+                        this.api.logging().logToOutput("Logging is paused.");
+                    }
+                } else {
+                    //SQLite mode
+                    //Case for YES is already handled, use the stored file
+                    if (loggingQuestionReply == JOptionPane.YES_OPTION) {
+                        preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.FALSE);
+                        this.api.logging().logToOutput("SQLite logging is enabled.");
+                    }
+                    //Case for the NO => Change DB file
+                    if (loggingQuestionReply == JOptionPane.NO_OPTION) {
+                        JFileChooser customStoreFileNameFileChooser = Utilities.createDBFileChooser();
+                        int dbFileSelectionReply = customStoreFileNameFileChooser.showDialog(burpFrame, "Use");
+                        if (dbFileSelectionReply == JFileChooser.APPROVE_OPTION) {
+                            customStoreFileName = customStoreFileNameFileChooser.getSelectedFile().getAbsolutePath().replaceAll("\\\\", "/");
+                        } else {
+                            JOptionPane.showMessageDialog(burpFrame, "The following database file will continue to be used:\n\r" + customStoreFileName, extensionName, JOptionPane.INFORMATION_MESSAGE);
+                        }
+                        preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.FALSE);
+                        this.api.logging().logToOutput("SQLite logging is enabled.");
+                    }
+                    //Case for the CANCEL => Pause the logging
+                    if (loggingQuestionReply == JOptionPane.CANCEL_OPTION) {
+                        preferences.setBoolean(ConfigMenu.PAUSE_LOGGING_CFG_KEY, Boolean.TRUE);
+                        this.api.logging().logToOutput("Logging is paused.");
+                    }
                 }
                 //Save the location of the database file chosen by the user
                 preferences.setString(ConfigMenu.DB_FILE_CUSTOM_LOCATION_CFG_KEY, customStoreFileName);
             } else {
                 this.api.logging().logToOutput("Logging is paused.");
             }
-            //Init logger and HTTP listener
-            ActivityLogger activityLogger = new ActivityLogger(customStoreFileName, this.api, trace);
-            ActivityHttpListener activityHttpListener = new ActivityHttpListener(activityLogger, trace);
+            //Init storage and HTTP listener
+            ActivityStorage activityStorage = ActivityStorageFactory.createStorage(preferences, customStoreFileName, this.api, trace);
+            ActivityHttpListener activityHttpListener = new ActivityHttpListener(activityStorage, trace);
             //Setup the configuration menu
-            configMenu = new ConfigMenu(this.api, trace, activityLogger);
+            configMenu = new ConfigMenu(this.api, trace, activityStorage);
             SwingUtilities.invokeLater(configMenu);
             //Register all listeners
             this.api.http().registerHttpHandler(activityHttpListener);
-            this.api.extension().registerUnloadingHandler(activityLogger);
+            this.api.extension().registerUnloadingHandler(activityStorage);
         } catch (Exception e) {
             String errMsg = "Cannot start the extension due to the following reason:\n\r" + e.getMessage();
             //Notification of the error in the dashboard tab


### PR DESCRIPTION
Hi there :)

First, thanks for taking the time to maintain this extension and for the rewrite under the montoya API :)

In the past, when using the extension on large bug bounty targets and extensive sessions, I had some performance issues, notably with scans or when browsing in parallel with different browsers / sessions.

I would like to implement a couple of new features in this extension amongst which :

1/Async writes to the DB
2/The ability to batch push requests to a postgreSQL database.
3/Some additional configuration options on the type of traffic to be logged (ex: being able to exclude intruder traffic temporarly)
This pull request implements 1/Async writes to the DB and 2/The ability to batch push requests to a postgreSQL database.

Disclosure: I (really) suck at Java, so this code was generated through the help of Claude 4. I then proceeded to test the code through :
- building it
- stress-testing the extension (multiple browsers, directory brute-force through intruder...).
- Swapping between the sqlite and psql storages
- Configuring a local PSQL db through docker-compose


